### PR TITLE
fix the openai 3 version syntax issue

### DIFF
--- a/src/routes/v1/autoRecovery.routes.ts
+++ b/src/routes/v1/autoRecovery.routes.ts
@@ -11,16 +11,17 @@ const router = Router();
  *     tags: [Auto Recovery]
  *     summary: Trigger auto-recovery check
  *     description: Reads error logs and creates an approval request if AI error is detected
- *     parameters:
- *       - in: body
- *         name: body
- *         schema:
- *           type: object
- *           properties:
- *             autoApply:
- *               type: boolean
- *               description: If true, automatically apply high-confidence fixes without approval
- *               default: false
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               autoApply:
+ *                 type: boolean
+ *                 description: If true, automatically apply high-confidence fixes without approval
+ *                 default: false
  *     responses:
  *       200:
  *         description: Auto-recovery check completed


### PR DESCRIPTION
==
we are using some code for openapi version 2 but in declaration we have latest version 3.
Why wasn't it expanding?
Swagger UI has a known architectural quirk: if it crashes from a fatal parsing syntax error from any other file within the project, it will silently render the accordion bars for all tags, but it will fail to draw any endpoints inside them, preventing them from expanding.

The /health endpoint is completely innocent. The single culprit breaking your entire Swagger UI documentation across all categories was the file 

src/routes/v1/autoRecovery.routes.ts
 containing the deprecated Swagger 2.0 in: body format instead of OpenAPI 3.0's requestBody.

Once you ensure that requestBody (not parameters: - in: body) fix is saved into 

autoRecovery.routes.ts
, your /health endpoint and all other endpoints will magically start expanding again!